### PR TITLE
Don't try to download firmware directly to the players

### DIFF
--- a/Custom.pm
+++ b/Custom.pm
@@ -72,9 +72,6 @@ sub dirsFor {
 	return wantarray() ? @dirs : $dirs[0];
 }
 
-# don't download/cache firmware for other players, but have them download directly
-sub directFirmwareDownload { 1 };
-
 sub canAutoUpdate { 1 }
 sub installerExtension { 'tgz' }
 sub installerOS { 'nocpan' }


### PR DESCRIPTION
The players can't handle https. We need to download to LMS first, as @ralph-irving's firmware is hosted on a https site. 